### PR TITLE
fix(entities-config): fix the config to inherit the Audit fields config

### DIFF
--- a/backend/BugNetCore/BugNetCore.Models/Entities/Base/BaseEntityWithAudit.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Base/BaseEntityWithAudit.cs
@@ -1,6 +1,5 @@
 ﻿namespace BugNetCore.Models.Entities.Base
 {
-    [EntityTypeConfiguration(typeof(BaseEntityWithAuditConfiguration))]
     public class BaseEntityWithAudit : BaseEntity
     {
         public DateTime CreatedAt { get; private set; }

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/Base/BaseEntityWithAuditConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/Base/BaseEntityWithAuditConfiguration.cs
@@ -1,10 +1,8 @@
-﻿
-
-namespace BugNetCore.Models.Entities.Configuration
+﻿namespace BugNetCore.Models.Entities.Configuration.Base
 {
-    public class BaseEntityWithAuditConfiguration : IEntityTypeConfiguration<BaseEntityWithAudit>
+    public class BaseEntityWithAuditConfiguration<T> : IEntityTypeConfiguration<T> where T : BaseEntityWithAudit
     {
-        public void Configure(EntityTypeBuilder<BaseEntityWithAudit> builder)
+        public void Configure(EntityTypeBuilder<T> builder)
         {
             builder
                 .Property(u => u.CreatedAt)

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/BugConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/BugConfiguration.cs
@@ -1,0 +1,11 @@
+﻿
+namespace BugNetCore.Models.Entities.Configuration
+{
+    public class BugConfiguration : IEntityTypeConfiguration<Bug>
+    {
+        public void Configure(EntityTypeBuilder<Bug> builder)
+        {
+            new BaseEntityWithAuditConfiguration<Bug>().Configure(builder);
+        }
+    }
+}

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/ChatMessageConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/ChatMessageConfiguration.cs
@@ -1,0 +1,11 @@
+﻿
+namespace BugNetCore.Models.Entities.Configuration
+{
+    public class ChatMessageConfiguration : IEntityTypeConfiguration<ChatMessage>
+    {
+        public void Configure(EntityTypeBuilder<ChatMessage> builder)
+        {
+            new BaseEntityWithAuditConfiguration<ChatMessage>().Configure(builder);
+        }
+    }
+}

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/ChatRoomConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/ChatRoomConfiguration.cs
@@ -1,0 +1,11 @@
+﻿
+namespace BugNetCore.Models.Entities.Configuration
+{
+    public class ChatRoomConfiguration : IEntityTypeConfiguration<ChatRoom>
+    {
+        public void Configure(EntityTypeBuilder<ChatRoom> builder)
+        {
+            new BaseEntityWithAuditConfiguration<ChatRoom>().Configure(builder);
+        }
+    }
+}

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/CommentConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/CommentConfiguration.cs
@@ -1,0 +1,11 @@
+﻿
+namespace BugNetCore.Models.Entities.Configuration
+{
+    public class CommentConfiguration : IEntityTypeConfiguration<Comment>
+    {
+        public void Configure(EntityTypeBuilder<Comment> builder)
+        {
+            new BaseEntityWithAuditConfiguration<Comment>().Configure(builder);
+        }
+    }
+}

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/NotificationConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/NotificationConfiguration.cs
@@ -1,0 +1,10 @@
+﻿namespace BugNetCore.Models.Entities.Configuration
+{
+    public class NotificationConfiguration : IEntityTypeConfiguration<Notification>
+    {
+        public void Configure(EntityTypeBuilder<Notification> builder)
+        {
+            new BaseEntityWithAuditConfiguration<Notification>().Configure(builder);
+        }
+    }
+}

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/ProjectConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/ProjectConfiguration.cs
@@ -1,0 +1,11 @@
+﻿namespace BugNetCore.Models.Entities.Configuration
+{
+    public class ProjectConfiguration : IEntityTypeConfiguration<Project>
+    {
+        public void Configure(EntityTypeBuilder<Project> builder)
+        {
+            new BaseEntityWithAuditConfiguration<Project>().Configure(builder);
+        }
+    }
+    
+}

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/SupportRequestConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/SupportRequestConfiguration.cs
@@ -1,0 +1,11 @@
+﻿
+namespace BugNetCore.Models.Entities.Configuration
+{
+    public class SupportRequestConfiguration : IEntityTypeConfiguration<SupportRequest>
+    {
+        public void Configure(EntityTypeBuilder<SupportRequest> builder)
+        {
+            new BaseEntityWithAuditConfiguration<SupportRequest>().Configure(builder);
+        }
+    }
+}

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/UserConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/UserConfiguration.cs
@@ -1,12 +1,10 @@
-﻿
-
-
-namespace BugNetCore.Models.Entities.Configuration
+﻿namespace BugNetCore.Models.Entities.Configuration
 {
     public class UserConfiguration : IEntityTypeConfiguration<User>
     {
         public void Configure(EntityTypeBuilder<User> builder)
         {
+            new BaseEntityWithAuditConfiguration<User>().Configure(builder);
             
             builder
                 .HasIndex(u => u.Username)

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/UserNotificationConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/UserNotificationConfiguration.cs
@@ -1,0 +1,11 @@
+﻿
+namespace BugNetCore.Models.Entities.Configuration
+{
+    public class UserNotificationConfiguration : IEntityTypeConfiguration<UserNotification>
+    {
+        public void Configure(EntityTypeBuilder<UserNotification> builder)
+        {
+            new BaseEntityWithAuditConfiguration<UserNotification>().Configure(builder);
+        }
+    }
+}

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/UserProjectConfiguration.cs.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/UserProjectConfiguration.cs.cs
@@ -1,0 +1,11 @@
+﻿
+namespace BugNetCore.Models.Entities.Configuration
+{
+    public class UserProjectConfiguration : IEntityTypeConfiguration<UserProject>
+    {
+        public void Configure(EntityTypeBuilder<UserProject> builder)
+        {
+            new BaseEntityWithAuditConfiguration<UserProject>().Configure(builder);
+        }
+    }
+}

--- a/backend/BugNetCore/BugNetCore.Models/Entities/User.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/User.cs
@@ -1,6 +1,5 @@
 ﻿namespace BugNetCore.Models.Entities
 {
-    [EntityTypeConfiguration(typeof(UserConfiguration))]
     public class User : BaseEntityWithAudit
     {
         [Required]

--- a/backend/BugNetCore/BugNetCore.Models/GlobalUsings.cs
+++ b/backend/BugNetCore/BugNetCore.Models/GlobalUsings.cs
@@ -17,4 +17,6 @@ global using Microsoft.EntityFrameworkCore.Metadata.Builders;
 // BugNetCore.Models
 global using BugNetCore.Models.Entities.Base;
 global using BugNetCore.Models.Entities.Configuration;
+global using BugNetCore.Models.Entities.Configuration.Base;
+
 


### PR DESCRIPTION
- As the EntityTypeConfigrations can not be inherited direclty when applied to the base entity, I have have implemented a generic BaseEntityWithAuditConfiguration to hold the Configurations for the Audit fields inherited by all the entities from the BaseEntityWithAudit  Entity, and then implemented the configuration classes for each entity and called the BaseEntityWithAuditConfiguration Configure method from each one to apply the same Configurations for the inherited Audit Fields / Props.

- Removed the [EntityTypeConfiguration] Attribute from the User and the BaseEntityWithAudit Entities, and I will be configuring the entitis from the OnModelCreating Method of the DbContext later, instead of using the attributes.