### PR TITLE
Bugfix/backend/postgres xmin concurrency

### DIFF
--- a/backend/BugNetCore/BugNetCore.Models/Entities/Base/BaseEntity.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Base/BaseEntity.cs
@@ -6,10 +6,10 @@ namespace BugNetCore.Models.Entities.Base
     public abstract class BaseEntity
     {
         [Key]
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public Guid Id { get; set; }
+        public Guid Id { get; set; } = Guid.NewGuid();
 
-        [Timestamp]
-        public byte[] TimeStamp { get; set; }
+        [Column("xmin", TypeName = "xid")]
+        [ConcurrencyCheck]
+        public uint RowVersion { get; set; }
     }
 }

--- a/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/Base/BaseEntityWithAuditConfiguration.cs
+++ b/backend/BugNetCore/BugNetCore.Models/Entities/Configuration/Base/BaseEntityWithAuditConfiguration.cs
@@ -11,8 +11,15 @@
             builder
                 .Property(u => u.LastModified)
                 .HasDefaultValueSql("now() at time zone 'utc'")
-                .ValueGeneratedOnAddOrUpdate();
+            .ValueGeneratedOnAddOrUpdate();
 
+            builder
+            .Property(u => u.RowVersion)
+            .IsConcurrencyToken()
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsRowVersion();
         }
     }
 }


### PR DESCRIPTION

- Replaced the TimeStamp with a RowVersion property that represents the PostgreSQL `xmin` column to ensure seamless experience with EFCore.
- Configured EFCore through the fluent API to ensure the entities are upadted in the change tracker after each transaction to reflect the new updated transction id on the xmin column.